### PR TITLE
Improve consistency with neo's codebase

### DIFF
--- a/NeoPubSub/NeoPubSub.cs
+++ b/NeoPubSub/NeoPubSub.cs
@@ -47,8 +47,7 @@ namespace Neo.Plugins
                 var txid = appExec.Transaction.Hash.ToString();
                 foreach (ApplicationExecutionResult p in appExec.ExecutionResults)
                 {
-
-                    if (p.VMState.ToString() == "HALT, BREAK")
+                    if (!p.VMState.HasFlag(VMState.FAULT))
                     {
                         foreach (NotifyEventArgs q in p.Notifications)
                         {


### PR DESCRIPTION
I've been trying to make sure that the NeoPubSub plugin only broadcasts events that are not the result of a FAULTy script execution, and while I think that the current plugin accomplishes this, after checking [neo's code](https://github.com/neo-project/neo/blob/master-2.x/neo/Ledger/Blockchain.cs#L587) I changed the extension's code in order to make sure that only script executions that end up being committed are processed.
Essentially I've replicated the check that is done on neo.

Again, with a high probability this PR doesn't change anything, so feel free to close it. I'm just creating it because after spending some time researching it and implementing this solution I thought it may interesting to other ppl.