### PR TITLE
Fix installation instructions

### DIFF
--- a/NeoPubSub/README.md
+++ b/NeoPubSub/README.md
@@ -11,8 +11,7 @@ git clone https://github.com/neo-plugins-coz/NeoPubSub
 cd NeoPubSub
 dotnet publish -c Release
 cp -r ./NeoPubSub {neo-cli folder}/Plugins
-cp ./bin/Release/netstandard2.0/publish/NeoPubSub.dll {neo-cli folder}/Plugins
-cp ./bin/Release/netstandard2.0/publish/Redis*.dll {neo-cli folder}
+cp ./bin/Release/netstandard2.0/publish/{NeoPubSub,StackExchange.Redis,System.Threading.Channels,System.Diagnostics.PerformanceCounter,Pipelines.Sockets.Unofficial}.dll {neo-cli folder}/Plugins
 ```
 
 ### Example PubSub session:


### PR DESCRIPTION
Currently there is no file that fits `Redis*.dll` so if the current instructions are followed it results in the plugin being installed but crashing because it can't find it's dependencies. 

This PR fixes that by making sure that all the dependencies are copied over.